### PR TITLE
Initialize rito-cli CLI skeleton

### DIFF
--- a/rito-cli/Cargo.toml
+++ b/rito-cli/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rito-cli"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+directories = "5"
+rusqlite = { version = "0.31", features = ["bundled"] }
+time = { version = "0.3", features = ["serde"] }

--- a/rito-cli/src/commands/goal.rs
+++ b/rito-cli/src/commands/goal.rs
@@ -1,0 +1,6 @@
+use crate::Result;
+
+pub fn run() -> Result<()> {
+    println!("Goal command executed");
+    Ok(())
+}

--- a/rito-cli/src/commands/habit.rs
+++ b/rito-cli/src/commands/habit.rs
@@ -1,0 +1,6 @@
+use crate::Result;
+
+pub fn run() -> Result<()> {
+    println!("Habit command executed");
+    Ok(())
+}

--- a/rito-cli/src/commands/journal.rs
+++ b/rito-cli/src/commands/journal.rs
@@ -1,0 +1,6 @@
+use crate::Result;
+
+pub fn run() -> Result<()> {
+    println!("Journal command executed");
+    Ok(())
+}

--- a/rito-cli/src/commands/mod.rs
+++ b/rito-cli/src/commands/mod.rs
@@ -1,0 +1,5 @@
+pub mod goal;
+pub mod habit;
+pub mod journal;
+pub mod report;
+pub mod task;

--- a/rito-cli/src/commands/report.rs
+++ b/rito-cli/src/commands/report.rs
@@ -1,0 +1,6 @@
+use crate::Result;
+
+pub fn run() -> Result<()> {
+    println!("Report command executed");
+    Ok(())
+}

--- a/rito-cli/src/commands/task.rs
+++ b/rito-cli/src/commands/task.rs
@@ -1,0 +1,6 @@
+use crate::Result;
+
+pub fn run() -> Result<()> {
+    println!("Task command executed");
+    Ok(())
+}

--- a/rito-cli/src/lib.rs
+++ b/rito-cli/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod commands;
+
+pub type Result<T> = std::result::Result<T, anyhow::Error>;

--- a/rito-cli/src/main.rs
+++ b/rito-cli/src/main.rs
@@ -1,0 +1,36 @@
+use clap::{Parser, Subcommand};
+
+use rito_cli::{Result, commands};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "rito-cli",
+    version,
+    about = "Rito command-line interface",
+    propagate_version = true
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    Goal,
+    Task,
+    Habit,
+    Journal,
+    Report,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Goal => commands::goal::run(),
+        Commands::Task => commands::task::run(),
+        Commands::Habit => commands::habit::run(),
+        Commands::Journal => commands::journal::run(),
+        Commands::Report => commands::report::run(),
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap a new cargo binary crate for the rito-cli project
- add clap-based CLI wiring with goal, task, habit, journal, and report subcommands
- introduce a shared library module that exposes the command modules and a common Result alias

## Testing
- cargo fmt
- cargo check *(fails: unable to download crates index due to CONNECT tunnel 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ed4846b98832fab3e71abb35e4236)